### PR TITLE
Connect new CSS and JS libraries to old HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
 		<title>edChain</title>
 
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="./vendor/bootstrap-3.3.7.css">
+		<link rel="stylesheet" href="./vendor/css/bootstrap.css">
 		<link rel="stylesheet" href="./styles.css">
 
 		<!-- Scripts -->
 		<script>delete module.exports</script>
 		<script src="./vendor/jquery-3.1.1.js"></script>
 		<script src="./vendor/mustache.min.js"></script>
-		<script src="./vendor/bootstrap-3.3.7.js"></script>
+		<script src="./vendor/js/bootstrap.js"></script>
 		<script src="./vendor/jsoneditor.min.js"></script>
 		<script src="./window.js"></script>
 

--- a/styles.css
+++ b/styles.css
@@ -7,3 +7,48 @@ html {
   /* This allows the window to be dragged when the hidden-inset option is used */
   -webkit-app-region: drag;
 }
+
+.nav {
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+.nav > li {
+  position: relative;
+  display: block;
+}
+.nav > li > a {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+}
+.nav > li > a:hover,
+.nav > li > a:focus {
+  text-decoration: none;
+  background-color: #eee;
+}
+.nav > li.disabled > a {
+  color: #777;
+}
+.nav > li.disabled > a:hover,
+.nav > li.disabled > a:focus {
+  color: #777;
+  text-decoration: none;
+  cursor: not-allowed;
+  background-color: transparent;
+}
+.nav .open > a,
+.nav .open > a:hover,
+.nav .open > a:focus {
+  background-color: #eee;
+  border-color: #337ab7;
+}
+.nav .nav-divider {
+  height: 1px;
+  margin: 9px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.nav > li > a > img {
+  max-width: none;
+}


### PR DESCRIPTION
Bootstrap 4's CSS file didn't have some of the styling, for the navigation bar, that Bootstrap 3's CSS file did so I copied some of the styling from `vendor/bootstrap.css` and pasted it into `styles.css`