### PR TITLE
Fix index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,14 @@
 		<title>edChain</title>
 
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="./vendor/css/bootstrap.css">
+		<link rel="stylesheet" href="./vendor/bootstrap-3.3.7.css">
 		<link rel="stylesheet" href="./styles.css">
 
 		<!-- Scripts -->
 		<script>delete module.exports</script>
 		<script src="./vendor/jquery-3.1.1.js"></script>
 		<script src="./vendor/mustache.min.js"></script>
-		<script src="./vendor/js/bootstrap.js"></script>
+		<script src="./vendor/bootstrap-3.3.7.js"></script>
 		<script src="./vendor/jsoneditor.min.js"></script>
 		<script src="./window.js"></script>
 


### PR DESCRIPTION
The JavaScript file that's included with Bootstrap 4 breaks the functionality that allows for a user to switch between panes when they click on their respective tabs